### PR TITLE
Remove header and revert to older version

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -29,11 +29,6 @@
     </button>
 
     <div class="container">
-        <header>
-            <h1>Course Materials Assistant</h1>
-            <p class="subtitle">Ask questions about courses, instructors, and content</p>
-        </header>
-
         <div class="main-content">
             <!-- Left Sidebar -->
             <aside class="sidebar">

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -66,26 +66,6 @@ body {
     padding: 0;
 }
 
-/* Header - Hidden */
-header {
-    display: none;
-}
-
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
 
 /* Main Content Area with Sidebar */
 .main-content {
@@ -839,15 +819,7 @@ details[open] .suggested-header::before {
     .chat-main {
         order: 1;
     }
-    
-    header {
-        padding: 1rem;
-    }
-    
-    header h1 {
-        font-size: 1.5rem;
-    }
-    
+
     .chat-messages {
         padding: 1rem;
     }


### PR DESCRIPTION
Fixes #2

Removes the header elements to revert to the older version of the interface while keeping the theme toggle functional.

## Changes
- Removed "Course Materials Assistant" header
- Removed "Ask questions about courses, instructors, and content" subtitle
- Removed horizontal row styling
- Cleaned up unused CSS for header elements
- Theme toggle button remains functional

Generated with [Claude Code](https://claude.ai/code)